### PR TITLE
Add code generation to Maven build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+src/generated

--- a/pom.xml
+++ b/pom.xml
@@ -10,5 +10,33 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   <dependencies>
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+      <version>1.7.7</version>
+    </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.avro</groupId>
+        <artifactId>avro-maven-plugin</artifactId>
+        <version>1.7.7</version>
+        <executions>
+          <execution>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>schema</goal>
+              <goal>protocol</goal>
+              <goal>idl-protocol</goal>
+            </goals>
+            <configuration>
+              <sourceDirectory>${project.basedir}/src/main/resources/</sourceDirectory>
+              <outputDirectory>${project.basedir}/src/generated/java/</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
In order to create a Java based Kafka consumer example, we need the generated code along with the schema. Since the schema is a resource in this project, doing the code generation in a depending project is problematic (you'd need to extract the schema file resource from the jar during build time, then run code generation on the locally extracted file, etc.). Hence, I added code generation at this level and the divolte-schema artifact now ships with generated code in it.
