### PR TITLE
Bump version to 0.2-SNAPSHOT. Added clientTimestamp field.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>io.divolte</groupId>
   <artifactId>divolte-schema</artifactId>
   <packaging>jar</packaging>
-  <version>0.1-SNAPSHOT</version>
+  <version>0.2-SNAPSHOT</version>
   <name>divolte-schema</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/resources/DefaultEventRecord.avsc
+++ b/src/main/resources/DefaultEventRecord.avsc
@@ -20,6 +20,10 @@
             "type": "long"
         },
         {
+            "name": "clientTimestamp",
+            "type": "long"
+        },
+        {
             "name": "remoteHost",
             "type": "string"
         },


### PR DESCRIPTION
A clientTimestamp field was added, as it will be added to the default mapping. Note that there is no default value for it.